### PR TITLE
Why do not you correct this?

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Some concrete examples of things you can do with the addon:
 * Stick a flat surface from one object against a flat surface on another object
 * Align something to an invisible axis, or shift that axis to a new location first and then rotate around it.
 
-See the simple demo clips below for a general sense of what the addon can do, read the Wiki above, or watch video tutorial on <a href="https://youtu.be/VBoic2MIC8U">YouTube (Link)</a>.
+See the simple demo clips below for a general sense of what the addon can do, read the Wiki above, or watch the video tutorial on <a href="https://youtu.be/VBoic2MIC8U">YouTube (Link)</a>.
 
 ![alt](http://i.imgur.com/hro9YEB.gif)
 ![alt](http://i.imgur.com/VSkjGdN.gif)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Some concrete examples of things you can do with the addon:
 
 See the simple demo clips below for a general sense of what the addon can do, read the Wiki above, or watch the full 30 minute demo video on <a href="https://www.youtube.com/watch?v=ebEkfAQ4OOk">YouTube (Link)</a>.
 
-<div>
-<div style="float:left"><img stlye="width:80px" src="http://i.stack.imgur.com/hi2Lw.gif"></div>
-<div style="float:left"><img stlye="width:80px" src="http://i.stack.imgur.com/dOOF8.gif"></div>
-<div style="float:left"><img stlye="width:80px" src="http://i.stack.imgur.com/IgMGY.gif"></div>
-<div style="float:left"><img stlye="width:80px" src="http://i.stack.imgur.com/05uXX.gif"></div>
-</div>
+![alt](http://i.imgur.com/hro9YEB.gif)
+![alt](http://i.imgur.com/VSkjGdN.gif)
+![alt](http://i.imgur.com/qlUZwPC.gif)
+![alt](http://i.imgur.com/JOa7Fcd.gif)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Some concrete examples of things you can do with the addon:
 * Stick a flat surface from one object against a flat surface on another object
 * Align something to an invisible axis, or shift that axis to a new location first and then rotate around it.
 
-See the simple demo clips below for a general sense of what the addon can do, read the Wiki above, or watch the full 30 minute demo video on <a href="https://www.youtube.com/watch?v=ebEkfAQ4OOk">YouTube (Link)</a>.
+See the simple demo clips below for a general sense of what the addon can do, read the Wiki above, or watch video tutorial on <a href="https://youtu.be/VBoic2MIC8U">YouTube (Link)</a>.
 
 ![alt](http://i.imgur.com/hro9YEB.gif)
 ![alt](http://i.imgur.com/VSkjGdN.gif)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Some concrete examples of things you can do with the addon:
 * Stick a flat surface from one object against a flat surface on another object
 * Align something to an invisible axis, or shift that axis to a new location first and then rotate around it.
 
-See the simple demo clips below for a general sense of what the addon can do, or watch the full 30 minute demo video on <a href="https://www.youtube.com/watch?v=ebEkfAQ4OOk">YouTube (Link)</a>.
+See the simple demo clips below for a general sense of what the addon can do, read the Wiki above, or watch the full 30 minute demo video on <a href="https://www.youtube.com/watch?v=ebEkfAQ4OOk">YouTube (Link)</a>.
 
 <div>
 <div style="float:left"><img stlye="width:80px" src="http://i.stack.imgur.com/hi2Lw.gif"></div>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Mesh Align Plus (Blender Addon)
-Mesh Align Plus is a precision modeling addon that lets you move mesh parts and objects around, by picking points of interest and using them as targets for alignments, rotations and other types of transformations.
+Mesh Align Plus helps you move things around, precisely: arrange objects in your scene, align mesh parts to each other while you're modeling, and create complex custom transformations using measurements from your models.
 
-For example: rest a plane against the tips of three separate pyramid objects...or select an edge and rotate part of your mesh around it (or even take that axis and shift it to a new location, then rotate from there).
+In short: you choose from a basic set of operations, pick reference points, and apply custom transformations to a variety of targets. Flexible reference picking and a depth of customization enable sophisticated results.
 
-The complete manual/wiki is here currently (visit for more info, including contact information): https://wiki.blender.org/index.php/Extensions:2.6/Py/Scripts/Modeling/Mesh_Align_Plus
+For example: Grab an edge, then rotate an object around it. Or, stick a flat surface from one object against a flat surface on another object. Measure the rotational difference between two edges, then rotate a mesh piece to match that angle on a completely unrelated object. Align something to an invisible axis, or shift that axis to a new location first and then rotate around it.
+
+The complete manual/wiki is here currently (visit for more info, including contact information): https://github.com/egtwobits/mesh-align-plus/wiki
 
 See the simple demo clips below for a general sense of what the addon can do, or watch the full 30 minute demo video on <a href="https://www.youtube.com/watch?v=ebEkfAQ4OOk">YouTube (Link)</a>.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Mesh Align Plus (Blender Addon)
 Mesh Align Plus helps you move things around, precisely: arrange objects in your scene, align mesh parts to each other while you're modeling, and create complex custom transformations using measurements from your models.
 
-In short: you choose from a basic set of operations, pick reference points, and apply custom transformations to a variety of targets. Flexible reference picking and a depth of customization enable sophisticated results.
+In short: You choose from a basic set of operations, pick reference points, and apply custom transformations to a variety of targets. Flexible reference picking and a depth of customization enable sophisticated results.
 
-For example: Grab an edge, then rotate an object around it. Or, stick a flat surface from one object against a flat surface on another object. Measure the rotational difference between two edges, then rotate a mesh piece to match that angle on a completely unrelated object. Align something to an invisible axis, or shift that axis to a new location first and then rotate around it.
-
-The complete manual/wiki is here currently (visit for more info, including contact information): https://github.com/egtwobits/mesh-align-plus/wiki
+Some concrete examples of things you can do with the addon:
+* Grab an edge, then rotate an object around it
+* Stick a flat surface from one object against a flat surface on another object
+* Align something to an invisible axis, or shift that axis to a new location first and then rotate around it.
 
 See the simple demo clips below for a general sense of what the addon can do, or watch the full 30 minute demo video on <a href="https://www.youtube.com/watch?v=ebEkfAQ4OOk">YouTube (Link)</a>.
 

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -18,7 +18,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 #
-# <pep8-80 compliant>
+# <pep8 compliant>
 
 
 # Blender requires addons to provide this information.
@@ -29,7 +29,7 @@ bl_info = {
         "based on geometry and measurements from your scene."
     ),
     "author": "Eric Gentry",
-    "version": (0, 3, 0),
+    "version": (0, 4, 0),
     "blender": (2, 69, 0),
     "location": (
         "3D View > Tools, and Properties -> Scene -> Mesh Align Plus"
@@ -39,8 +39,7 @@ bl_info = {
         "not currently supported."
     ),
     "wiki_url": (
-        "https://wiki.blender.org/index.php/Extensions:2.6/Py/"
-        "Scripts/Modeling/Mesh_Align_Plus"
+        "https://github.com/egtwobits/mesh-align-plus/wiki"
     ),
     "support": "COMMUNITY",
     "category": "Mesh"

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -2598,6 +2598,72 @@ class GrabPointSlot2Loc(GrabFromGeometryBase):
     quick_op_target = "SLOT2"
 
 
+class PointGrabAvg(GrabAverageLocationBase):
+    bl_idname = "maplus.pointgrabavg"
+    bl_label = "Grab Average Global Coordinates From Selected Points"
+    bl_description = (
+        "Grabs average global coordinates from selected vertices in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('point',)
+    multiply_by_world_matrix = True
+
+
+class LineStartGrabAvg(GrabAverageLocationBase):
+    bl_idname = "maplus.linestartgrabavg"
+    bl_label = "Grab Average Global Coordinates From Selected Points"
+    bl_description = (
+        "Grabs average global coordinates from selected vertices in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('line_start',)
+    multiply_by_world_matrix = True
+
+
+class LineEndGrabAvg(GrabAverageLocationBase):
+    bl_idname = "maplus.lineendgrabavg"
+    bl_label = "Grab Average Global Coordinates From Selected Points"
+    bl_description = (
+        "Grabs average global coordinates from selected vertices in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('line_end',)
+    multiply_by_world_matrix = True
+
+
+class PlaneAGrabAvg(GrabAverageLocationBase):
+    bl_idname = "maplus.planeagrabavg"
+    bl_label = "Grab Average Global Coordinates From Selected Points"
+    bl_description = (
+        "Grabs average global coordinates from selected vertices in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('plane_pt_a',)
+    multiply_by_world_matrix = True
+
+
+class PlaneBGrabAvg(GrabAverageLocationBase):
+    bl_idname = "maplus.planebgrabavg"
+    bl_label = "Grab Average Global Coordinates From Selected Points"
+    bl_description = (
+        "Grabs average global coordinates from selected vertices in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('plane_pt_b',)
+    multiply_by_world_matrix = True
+
+
+class PlaneCGrabAvg(GrabAverageLocationBase):
+    bl_idname = "maplus.planecgrabavg"
+    bl_label = "Grab Average Global Coordinates From Selected Points"
+    bl_description = (
+        "Grabs average global coordinates from selected vertices in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('plane_pt_c',)
+    multiply_by_world_matrix = True
+
+
 class Slot1PointGrabAvg(GrabAverageLocationBase):
     bl_idname = "maplus.slot1pointgrabavg"
     bl_label = "Grab Average Global Coordinates From Selected Points"
@@ -9361,73 +9427,57 @@ class MAPlusGui(bpy.types.Panel):
                 )
                 item_info_col.separator()
 
-                item_info_col.label('Pt. Origin:')
-                pt_coord_items = item_info_col.split(percentage=.75)
-                typein_and_grab = pt_coord_items.column()
-                pt_coord_uppers = typein_and_grab.row()
-
-                pt_coord_uppers_leftside = pt_coord_uppers.row(align=True)
-                pt_coord_uppers_leftside.alignment = 'LEFT'
-                pt_coord_uppers_leftside.label("Send:")
-                pt_coord_uppers_leftside.operator(
-                    "maplus.sendpointtocursor",
-                    icon='CURSOR',
-                    text=""
+                layout_coordvec(
+                    parent_layout=item_info_col,
+                    coordvec_label="Point Coordinates:",
+                    op_id_cursor_grab=(
+                        "maplus.grabpointfromcursor"
+                    ),
+                    op_id_avg_grab=(
+                        "maplus.pointgrabavg"
+                    ),
+                    op_id_local_grab=(
+                        "maplus.grabpointfromactivelocal"
+                    ),
+                    op_id_global_grab=(
+                        "maplus.grabpointfromactiveglobal"
+                    ),
+                    coord_container=active_item,
+                    coord_attribute="point",
+                    op_id_cursor_send=(
+                        "maplus.sendpointtocursor"
+                    )
                 )
 
-                pt_coord_uppers_rightside = pt_coord_uppers.row(align=True)
-                pt_coord_uppers_rightside.alignment = 'RIGHT'
-                pt_coord_uppers_rightside.label("Grab:")
-                pt_coord_uppers_rightside.operator(
-                    "maplus.grabpointfromcursor",
-                    icon='CURSOR',
-                    text=""
-                )
-                pt_coord_uppers_rightside.operator(
-                    "maplus.grabpointfromactivelocal",
-                    icon='VERTEXSEL',
-                    text=""
-                )
-                pt_coord_uppers_rightside.operator(
-                    "maplus.grabpointfromactiveglobal",
-                    icon='WORLD',
-                    text=""
-                )
-                typein_and_grab.prop(
-                    bpy.types.AnyType(active_item),
-                    'point',
-                    ""
-                )
-
-                component_changers = pt_coord_items.row()
-                zero_components = component_changers.column(align=True)
-                zero_components.label("Set Zeroes:")
-                zero_components.operator(
-                    "maplus.zerootherpointx",
-                    text="X00"
-                )
-                zero_components.operator(
-                    "maplus.zerootherpointy",
-                    text="0Y0"
-                )
-                zero_components.operator(
-                    "maplus.zerootherpointz",
-                    text="00Z"
-                )
-                one_components = component_changers.column(align=True)
-                one_components.label("Set Ones:")
-                one_components.operator(
-                    "maplus.oneotherpointx",
-                    text="X11"
-                )
-                one_components.operator(
-                    "maplus.oneotherpointy",
-                    text="1Y1"
-                )
-                one_components.operator(
-                    "maplus.oneotherpointz",
-                    text="11Z"
-                )
+                # component_changers = pt_coord_items.row()
+                # zero_components = component_changers.column(align=True)
+                # zero_components.label("Set Zeroes:")
+                # zero_components.operator(
+                    # "maplus.zerootherpointx",
+                    # text="X00"
+                # )
+                # zero_components.operator(
+                    # "maplus.zerootherpointy",
+                    # text="0Y0"
+                # )
+                # zero_components.operator(
+                    # "maplus.zerootherpointz",
+                    # text="00Z"
+                # )
+                # one_components = component_changers.column(align=True)
+                # one_components.label("Set Ones:")
+                # one_components.operator(
+                    # "maplus.oneotherpointx",
+                    # text="X11"
+                # )
+                # one_components.operator(
+                    # "maplus.oneotherpointy",
+                    # text="1Y1"
+                # )
+                # one_components.operator(
+                    # "maplus.oneotherpointz",
+                    # text="11Z"
+                # )
                 item_info_col.separator()
                 item_info_col.operator(
                     "maplus.duplicateitembase",
@@ -9477,151 +9527,118 @@ class MAPlusGui(bpy.types.Panel):
                 )
                 item_info_col.separator()
 
-                item_info_col.label("Start:")
-                ln_start_items = item_info_col.split(percentage=.75)
-                typein_and_grab_start = ln_start_items.column()
-                ln_start_uppers = typein_and_grab_start.split(percentage=.33)
-                ln_start_swap = ln_start_uppers.row(align=True)
-                ln_start_swap.label("Swap:")
-                ln_start_swap.operator(
-                    "maplus.swaplinepoints",
-                    text="End"
-                )
-
-                ln_start_uppers_rightside = ln_start_uppers.row(align=True)
-                ln_start_uppers_rightside.alignment = 'RIGHT'
-
-                ln_start_uppers_rightside.label("Send:")
-                ln_start_uppers_rightside.operator(
-                    "maplus.sendlinestarttocursor",
-                    icon='CURSOR',
-                    text=""
-                )
-
-                ln_start_uppers_rightside.label("Grab:")
-                ln_start_uppers_rightside.operator(
-                    "maplus.grablinestartfromcursor",
-                    icon='CURSOR',
-                    text=""
-                )
-                ln_start_uppers_rightside.operator(
-                    "maplus.grablinestartfromactivelocal",
-                    icon='VERTEXSEL',
-                    text=""
-                )
-                ln_start_uppers_rightside.operator(
-                    "maplus.grablinestartfromactiveglobal",
-                    icon='WORLD',
-                    text=""
-                )
-                typein_and_grab_start.prop(
-                    bpy.types.AnyType(active_item),
-                    'line_start',
-                    ""
+                layout_coordvec(
+                    parent_layout=item_info_col,
+                    coordvec_label="Start:",
+                    op_id_cursor_grab=(
+                        "maplus.grablinestartfromcursor"
+                    ),
+                    op_id_avg_grab=(
+                        "maplus.linestartgrabavg"
+                    ),
+                    op_id_local_grab=(
+                        "maplus.grablinestartfromactivelocal"
+                    ),
+                    op_id_global_grab=(
+                        "maplus.grablinestartfromactiveglobal"
+                    ),
+                    coord_container=active_item,
+                    coord_attribute="line_start",
+                    op_id_cursor_send=(
+                        "maplus.sendlinestarttocursor"
+                    ),
+                    op_id_text_tuple_swap_first=(
+                        "maplus.swaplinepoints",
+                        "End"
+                    )
                 )
                 item_info_col.separator()
 
-                component_changers_start = ln_start_items.row()
-                zero_components = component_changers_start.column(align=True)
-                zero_components.label("Set Zeroes:")
-                zero_components.operator(
-                    "maplus.zerootherlinestartx",
-                    text="X00"
-                )
-                zero_components.operator(
-                    "maplus.zerootherlinestarty",
-                    text="0Y0"
-                )
-                zero_components.operator(
-                    "maplus.zerootherlinestartz",
-                    text="00Z"
-                )
-                one_components = component_changers_start.column(align=True)
-                one_components.label("Set Ones:")
-                one_components.operator(
-                    "maplus.oneotherlinestartx",
-                    text="X11"
-                )
-                one_components.operator(
-                    "maplus.oneotherlinestarty",
-                    text="1Y1"
-                )
-                one_components.operator(
-                    "maplus.oneotherlinestartz",
-                    text="11Z"
+                # component_changers_start = ln_start_items.row()
+                # zero_components = component_changers_start.column(align=True)
+                # zero_components.label("Set Zeroes:")
+                # zero_components.operator(
+                    # "maplus.zerootherlinestartx",
+                    # text="X00"
+                # )
+                # zero_components.operator(
+                    # "maplus.zerootherlinestarty",
+                    # text="0Y0"
+                # )
+                # zero_components.operator(
+                    # "maplus.zerootherlinestartz",
+                    # text="00Z"
+                # )
+                # one_components = component_changers_start.column(align=True)
+                # one_components.label("Set Ones:")
+                # one_components.operator(
+                    # "maplus.oneotherlinestartx",
+                    # text="X11"
+                # )
+                # one_components.operator(
+                    # "maplus.oneotherlinestarty",
+                    # text="1Y1"
+                # )
+                # one_components.operator(
+                    # "maplus.oneotherlinestartz",
+                    # text="11Z"
+                # )
+
+                layout_coordvec(
+                    parent_layout=item_info_col,
+                    coordvec_label="End:",
+                    op_id_cursor_grab=(
+                        "maplus.grablineendfromcursor"
+                    ),
+                    op_id_avg_grab=(
+                        "maplus.lineendgrabavg"
+                    ),
+                    op_id_local_grab=(
+                        "maplus.grablineendfromactivelocal"
+                    ),
+                    op_id_global_grab=(
+                        "maplus.grablineendfromactiveglobal"
+                    ),
+                    coord_container=active_item,
+                    coord_attribute="line_end",
+                    op_id_cursor_send=(
+                        "maplus.sendlineendtocursor"
+                    ),
+                    op_id_text_tuple_swap_first=(
+                        "maplus.swaplinepoints",
+                        "Start"
+                    )
                 )
 
-                item_info_col.label("End:")
-                ln_end_items = item_info_col.split(percentage=.75)
-                typein_and_grab_end = ln_end_items.column()
-                ln_end_uppers = typein_and_grab_end.split(percentage=.33)
-                ln_end_swap = ln_end_uppers.row(align=True)
-                ln_end_swap.label("Swap:")
-                ln_end_swap.operator(
-                    "maplus.swaplinepoints",
-                    text="Start"
-                )
-
-                ln_end_uppers_rightside = ln_end_uppers.row(align=True)
-                ln_end_uppers_rightside.alignment = 'RIGHT'
-                ln_end_uppers_rightside.label("Send:")
-                ln_end_uppers_rightside.operator(
-                    "maplus.sendlineendtocursor",
-                    icon='CURSOR',
-                    text=""
-                )
-
-                ln_end_uppers_rightside.label("Grab:")
-                ln_end_uppers_rightside.operator(
-                    "maplus.grablineendfromcursor",
-                    icon='CURSOR',
-                    text=""
-                )
-                ln_end_uppers_rightside.operator(
-                    "maplus.grablineendfromactivelocal",
-                    icon='VERTEXSEL',
-                    text=""
-                )
-                ln_end_uppers_rightside.operator(
-                    "maplus.grablineendfromactiveglobal",
-                    icon='WORLD',
-                    text=""
-                )
-                typein_and_grab_end.prop(
-                    bpy.types.AnyType(active_item),
-                    'line_end',
-                    ""
-                )
-
-                component_changers_end = ln_end_items.row()
-                zero_components = component_changers_end.column(align=True)
-                zero_components.label("Set Zeroes:")
-                zero_components.operator(
-                    "maplus.zerootherlineendx",
-                    text="X00"
-                )
-                zero_components.operator(
-                    "maplus.zerootherlineendy",
-                    text="0Y0"
-                )
-                zero_components.operator(
-                    "maplus.zerootherlineendz",
-                    text="00Z"
-                )
-                one_components = component_changers_end.column(align=True)
-                one_components.label("Set Ones:")
-                one_components.operator(
-                    "maplus.oneotherlineendx",
-                    text="X11"
-                )
-                one_components.operator(
-                    "maplus.oneotherlineendy",
-                    text="1Y1"
-                )
-                one_components.operator(
-                    "maplus.oneotherlineendz",
-                    text="11Z"
-                )
+                # component_changers_end = ln_end_items.row()
+                # zero_components = component_changers_end.column(align=True)
+                # zero_components.label("Set Zeroes:")
+                # zero_components.operator(
+                    # "maplus.zerootherlineendx",
+                    # text="X00"
+                # )
+                # zero_components.operator(
+                    # "maplus.zerootherlineendy",
+                    # text="0Y0"
+                # )
+                # zero_components.operator(
+                    # "maplus.zerootherlineendz",
+                    # text="00Z"
+                # )
+                # one_components = component_changers_end.column(align=True)
+                # one_components.label("Set Ones:")
+                # one_components.operator(
+                    # "maplus.oneotherlineendx",
+                    # text="X11"
+                # )
+                # one_components.operator(
+                    # "maplus.oneotherlineendy",
+                    # text="1Y1"
+                # )
+                # one_components.operator(
+                    # "maplus.oneotherlineendz",
+                    # text="11Z"
+                # )
                 item_info_col.separator()
                 item_info_col.operator(
                     "maplus.duplicateitembase",
@@ -9643,248 +9660,199 @@ class MAPlusGui(bpy.types.Panel):
                 )
                 item_info_col.separator()
 
-                item_info_col.label("Pt. A:")
-                plane_a_items = item_info_col.split(percentage=.75)
-                typein_and_grab_plna = plane_a_items.column()
-                plane_a_uppers = typein_and_grab_plna.split(percentage=.33)
-
-                plane_a_swap = plane_a_uppers.row(align=True)
-                plane_a_swap.label("Swap With:")
-                plane_a_swap.operator(
-                    "maplus.swapplaneaplaneb",
-                    text="B"
-                )
-                plane_a_swap.operator(
-                    "maplus.swapplaneaplanec",
-                    text="C"
-                )
-
-                plane_a_uppers_rightside = plane_a_uppers.row(align=True)
-                plane_a_uppers_rightside.alignment = 'RIGHT'
-                plane_a_uppers_rightside.label("Send:")
-                plane_a_uppers_rightside.operator(
-                    "maplus.sendplaneatocursor",
-                    icon='CURSOR',
-                    text=""
-                )
-
-                plane_a_uppers_rightside.label("Grab:")
-                plane_a_uppers_rightside.operator(
-                    "maplus.grabplaneafromcursor",
-                    icon='CURSOR',
-                    text=""
-                )
-                plane_a_uppers_rightside.operator(
-                    "maplus.grabplaneafromactivelocal",
-                    icon='VERTEXSEL',
-                    text=""
-                )
-                plane_a_uppers_rightside.operator(
-                    "maplus.grabplaneafromactiveglobal",
-                    icon='WORLD',
-                    text=""
-                )
-                typein_and_grab_plna.prop(
-                    bpy.types.AnyType(active_item),
-                    'plane_pt_a',
-                    ""
+                layout_coordvec(
+                    parent_layout=item_info_col,
+                    coordvec_label="Pt. A:",
+                    op_id_cursor_grab=(
+                        "maplus.grabplaneafromcursor"
+                    ),
+                    op_id_avg_grab=(
+                        "maplus.planeagrabavg"
+                    ),
+                    op_id_local_grab=(
+                        "maplus.grabplaneafromactivelocal"
+                    ),
+                    op_id_global_grab=(
+                        "maplus.grabplaneafromactiveglobal"
+                    ),
+                    coord_container=active_item,
+                    coord_attribute="plane_pt_a",
+                    op_id_cursor_send=(
+                        "maplus.sendplaneatocursor"
+                    ),
+                    op_id_text_tuple_swap_first=(
+                        "maplus.swapplaneaplaneb",
+                        "B"
+                    ),
+                    op_id_text_tuple_swap_second=(
+                        "maplus.swapplaneaplanec",
+                        "C"
+                    )
                 )
                 item_info_col.separator()
 
-                component_changers_plna = plane_a_items.row()
-                zero_components_plna = component_changers_plna.column(
-                    align=True
-                )
-                zero_components_plna.label("Set Zeroes:")
-                zero_components_plna.operator(
-                    "maplus.zerootherplanepointax",
-                    text="X00"
-                )
-                zero_components_plna.operator(
-                    "maplus.zerootherplanepointay",
-                    text="0Y0"
-                )
-                zero_components_plna.operator(
-                    "maplus.zerootherplanepointaz",
-                    text="00Z"
-                )
-                one_components_plna = component_changers_plna.column(
-                    align=True
-                )
-                one_components_plna.label("Set Ones:")
-                one_components_plna.operator(
-                    "maplus.oneotherplanepointax",
-                    text="X11"
-                )
-                one_components_plna.operator(
-                    "maplus.oneotherplanepointay",
-                    text="1Y1"
-                )
-                one_components_plna.operator(
-                    "maplus.oneotherplanepointaz",
-                    text="11Z"
-                )
+                # component_changers_plna = plane_a_items.row()
+                # zero_components_plna = component_changers_plna.column(
+                    # align=True
+                # )
+                # zero_components_plna.label("Set Zeroes:")
+                # zero_components_plna.operator(
+                    # "maplus.zerootherplanepointax",
+                    # text="X00"
+                # )
+                # zero_components_plna.operator(
+                    # "maplus.zerootherplanepointay",
+                    # text="0Y0"
+                # )
+                # zero_components_plna.operator(
+                    # "maplus.zerootherplanepointaz",
+                    # text="00Z"
+                # )
+                # one_components_plna = component_changers_plna.column(
+                    # align=True
+                # )
+                # one_components_plna.label("Set Ones:")
+                # one_components_plna.operator(
+                    # "maplus.oneotherplanepointax",
+                    # text="X11"
+                # )
+                # one_components_plna.operator(
+                    # "maplus.oneotherplanepointay",
+                    # text="1Y1"
+                # )
+                # one_components_plna.operator(
+                    # "maplus.oneotherplanepointaz",
+                    # text="11Z"
+                # )
 
-                item_info_col.label("Pt. B (Pivot):")
-                plane_b_items = item_info_col.split(percentage=.75)
-                typein_and_grab_plnb = plane_b_items.column()
-                plane_b_uppers = typein_and_grab_plnb.split(percentage=.33)
-                plane_b_swap = plane_b_uppers.row(align=True)
-                plane_b_swap.label("Swap With:")
-                plane_b_swap.operator(
-                    "maplus.swapplaneaplaneb",
-                    text="A"
-                )
-                plane_b_swap.operator(
-                    "maplus.swapplanebplanec",
-                    text="C"
-                )
-
-                plane_b_uppers_rightside = plane_b_uppers.row(align=True)
-                plane_b_uppers_rightside.alignment = 'RIGHT'
-                plane_b_uppers_rightside.label("Send:")
-                plane_b_uppers_rightside.operator(
-                    "maplus.sendplanebtocursor",
-                    icon='CURSOR',
-                    text=""
-                )
-
-                plane_b_uppers_rightside.label("Grab:")
-                plane_b_uppers_rightside.operator(
-                    "maplus.grabplanebfromcursor",
-                    icon='CURSOR',
-                    text=""
-                )
-                plane_b_uppers_rightside.operator(
-                    "maplus.grabplanebfromactivelocal",
-                    icon='VERTEXSEL',
-                    text=""
-                )
-                plane_b_uppers_rightside.operator(
-                    "maplus.grabplanebfromactiveglobal",
-                    icon='WORLD',
-                    text=""
-                )
-                typein_and_grab_plnb.prop(
-                    bpy.types.AnyType(active_item),
-                    'plane_pt_b',
-                    ""
+                layout_coordvec(
+                    parent_layout=item_info_col,
+                    coordvec_label="Pt. B:",
+                    op_id_cursor_grab=(
+                        "maplus.grabplanebfromcursor"
+                    ),
+                    op_id_avg_grab=(
+                        "maplus.planebgrabavg"
+                    ),
+                    op_id_local_grab=(
+                        "maplus.grabplanebfromactivelocal"
+                    ),
+                    op_id_global_grab=(
+                        "maplus.grabplanebfromactiveglobal"
+                    ),
+                    coord_container=active_item,
+                    coord_attribute="plane_pt_b",
+                    op_id_cursor_send=(
+                        "maplus.sendplanebtocursor"
+                    ),
+                    op_id_text_tuple_swap_first=(
+                        "maplus.swapplaneaplaneb",
+                        "A"
+                    ),
+                    op_id_text_tuple_swap_second=(
+                        "maplus.swapplanebplanec",
+                        "C"
+                    )
                 )
                 item_info_col.separator()
 
-                component_changers_plnb = plane_b_items.row()
-                zero_components_plnb = component_changers_plnb.column(
-                    align=True
-                )
-                zero_components_plnb.label("Set Zeroes:")
-                zero_components_plnb.operator(
-                    "maplus.zerootherplanepointbx",
-                    text="X00"
-                )
-                zero_components_plnb.operator(
-                    "maplus.zerootherplanepointby",
-                    text="0Y0"
-                )
-                zero_components_plnb.operator(
-                    "maplus.zerootherplanepointbz",
-                    text="00Z"
-                )
-                one_components_plnb = component_changers_plnb.column(
-                    align=True
-                )
-                one_components_plnb.label("Set Ones:")
-                one_components_plnb.operator(
-                    "maplus.oneotherplanepointbx",
-                    text="X11"
-                )
-                one_components_plnb.operator(
-                    "maplus.oneotherplanepointby",
-                    text="1Y1"
-                )
-                one_components_plnb.operator(
-                    "maplus.oneotherplanepointbz",
-                    text="11Z"
+                # component_changers_plnb = plane_b_items.row()
+                # zero_components_plnb = component_changers_plnb.column(
+                    # align=True
+                # )
+                # zero_components_plnb.label("Set Zeroes:")
+                # zero_components_plnb.operator(
+                    # "maplus.zerootherplanepointbx",
+                    # text="X00"
+                # )
+                # zero_components_plnb.operator(
+                    # "maplus.zerootherplanepointby",
+                    # text="0Y0"
+                # )
+                # zero_components_plnb.operator(
+                    # "maplus.zerootherplanepointbz",
+                    # text="00Z"
+                # )
+                # one_components_plnb = component_changers_plnb.column(
+                    # align=True
+                # )
+                # one_components_plnb.label("Set Ones:")
+                # one_components_plnb.operator(
+                    # "maplus.oneotherplanepointbx",
+                    # text="X11"
+                # )
+                # one_components_plnb.operator(
+                    # "maplus.oneotherplanepointby",
+                    # text="1Y1"
+                # )
+                # one_components_plnb.operator(
+                    # "maplus.oneotherplanepointbz",
+                    # text="11Z"
+                # )
+
+                layout_coordvec(
+                    parent_layout=item_info_col,
+                    coordvec_label="Pt. C:",
+                    op_id_cursor_grab=(
+                        "maplus.grabplanecfromcursor"
+                    ),
+                    op_id_avg_grab=(
+                        "maplus.planecgrabavg"
+                    ),
+                    op_id_local_grab=(
+                        "maplus.grabplanecfromactivelocal"
+                    ),
+                    op_id_global_grab=(
+                        "maplus.grabplanecfromactiveglobal"
+                    ),
+                    coord_container=active_item,
+                    coord_attribute="plane_pt_c",
+                    op_id_cursor_send=(
+                        "maplus.sendplanectocursor"
+                    ),
+                    op_id_text_tuple_swap_first=(
+                        "maplus.swapplaneaplanec",
+                        "A"
+                    ),
+                    op_id_text_tuple_swap_second=(
+                        "maplus.swapplanebplanec",
+                        "B"
+                    )
                 )
 
-                item_info_col.label("Pt. C:")
-                plane_c_items = item_info_col.split(percentage=.75)
-                typein_and_grab_plnc = plane_c_items.column()
-                plane_c_uppers = typein_and_grab_plnc.split(percentage=.33)
-                plane_c_swap = plane_c_uppers.row(align=True)
-                plane_c_swap.label("Swap With:")
-                plane_c_swap.operator(
-                    "maplus.swapplaneaplanec",
-                    text="A"
-                )
-                plane_c_swap.operator(
-                    "maplus.swapplanebplanec",
-                    text="B"
-                )
-
-                plane_c_uppers_rightside = plane_c_uppers.row(align=True)
-                plane_c_uppers_rightside.alignment = 'RIGHT'
-                plane_c_uppers_rightside.label("Send:")
-                plane_c_uppers_rightside.operator(
-                    "maplus.sendplanectocursor",
-                    icon='CURSOR',
-                    text=""
-                )
-
-                plane_c_uppers_rightside.label("Grab:")
-                plane_c_uppers_rightside.operator(
-                    "maplus.grabplanecfromcursor",
-                    icon='CURSOR',
-                    text=""
-                )
-                plane_c_uppers_rightside.operator(
-                    "maplus.grabplanecfromactivelocal",
-                    icon='VERTEXSEL',
-                    text=""
-                )
-                plane_c_uppers_rightside.operator(
-                    "maplus.grabplanecfromactiveglobal",
-                    icon='WORLD',
-                    text=""
-                )
-                typein_and_grab_plnc.prop(
-                    bpy.types.AnyType(active_item),
-                    'plane_pt_c',
-                    ""
-                )
-
-                component_changers_plnc = plane_c_items.row()
-                zero_components_plnc = component_changers_plnc.column(
-                    align=True
-                )
-                zero_components_plnc.label("Set Zeroes:")
-                zero_components_plnc.operator(
-                    "maplus.zerootherplanepointcx",
-                    text="X00"
-                )
-                zero_components_plnc.operator(
-                    "maplus.zerootherplanepointcy",
-                    text="0Y0"
-                )
-                zero_components_plnc.operator(
-                    "maplus.zerootherplanepointcz",
-                    text="00Z"
-                )
-                one_components_plnc = component_changers_plnc.column(
-                    align=True
-                )
-                one_components_plnc.label("Set Ones:")
-                one_components_plnc.operator(
-                    "maplus.oneotherplanepointcx",
-                    text="X11"
-                )
-                one_components_plnc.operator(
-                    "maplus.oneotherplanepointcy",
-                    text="1Y1"
-                )
-                one_components_plnc.operator(
-                    "maplus.oneotherplanepointcz",
-                    text="11Z"
-                )
+                # component_changers_plnc = plane_c_items.row()
+                # zero_components_plnc = component_changers_plnc.column(
+                    # align=True
+                # )
+                # zero_components_plnc.label("Set Zeroes:")
+                # zero_components_plnc.operator(
+                    # "maplus.zerootherplanepointcx",
+                    # text="X00"
+                # )
+                # zero_components_plnc.operator(
+                    # "maplus.zerootherplanepointcy",
+                    # text="0Y0"
+                # )
+                # zero_components_plnc.operator(
+                    # "maplus.zerootherplanepointcz",
+                    # text="00Z"
+                # )
+                # one_components_plnc = component_changers_plnc.column(
+                    # align=True
+                # )
+                # one_components_plnc.label("Set Ones:")
+                # one_components_plnc.operator(
+                    # "maplus.oneotherplanepointcx",
+                    # text="X11"
+                # )
+                # one_components_plnc.operator(
+                    # "maplus.oneotherplanepointcy",
+                    # text="1Y1"
+                # )
+                # one_components_plnc.operator(
+                    # "maplus.oneotherplanepointcz",
+                    # text="11Z"
+                # )
                 item_info_col.separator()
                 item_info_col.operator(
                     "maplus.duplicateitembase",

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -8899,8 +8899,8 @@ class QuickComposeNewLineVectorAddition(ComposeNewLineVectorAdditionBase):
         addon_data = bpy.context.scene.maplus_data
 
         if (addon_data.quick_calc_check_types and
-                (addon_data.internal_storage_slot_1.kind != 'POINT' or
-                 addon_data.internal_storage_slot_2.kind != 'POINT')):
+                (addon_data.internal_storage_slot_1.kind != 'LINE' or
+                 addon_data.internal_storage_slot_2.kind != 'LINE')):
             return False
         return True
 
@@ -9003,8 +9003,8 @@ class QuickComposeNewLineVectorSubtraction(ComposeNewLineVectorSubtractionBase):
         addon_data = bpy.context.scene.maplus_data
 
         if (addon_data.quick_calc_check_types and
-                (addon_data.internal_storage_slot_1.kind != 'POINT' or
-                 addon_data.internal_storage_slot_2.kind != 'POINT')):
+                (addon_data.internal_storage_slot_1.kind != 'LINE' or
+                 addon_data.internal_storage_slot_2.kind != 'LINE')):
             return False
         return True
 

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -6239,6 +6239,12 @@ class ScaleMatchEdgeBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode
@@ -6614,6 +6620,12 @@ class AlignPointsBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode
@@ -6884,6 +6896,12 @@ class DirectionalSlideBase(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode
@@ -7160,6 +7178,12 @@ class AxisRotateBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode
@@ -7457,6 +7481,12 @@ class AlignLinesBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode
@@ -7772,6 +7802,12 @@ class AlignPlanesBase(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode
@@ -8164,6 +8200,12 @@ class QuickAlignObjects(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
+        if not bpy.context.active_object:
+            self.report(
+                {'ERROR'},
+                'Cannot complete: no active object.'
+            )
+            return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
         prims = addon_data.prim_list
         previous_mode = bpy.context.active_object.mode

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -11385,7 +11385,7 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
 
                 layout_coordvec(
                     parent_layout=apl_src_geom_editor,
-                    coordvec_label="Pt. B:",
+                    coordvec_label="Pt. B (Pivot):",
                     op_id_cursor_grab=(
                         "maplus.quickaplsrcgrabplanebfromcursor"
                     ),
@@ -14222,7 +14222,7 @@ class CalculateAndComposeGUI(bpy.types.Panel):
 
                 layout_coordvec(
                     parent_layout=calcresult_geom_editor,
-                    coordvec_label="Pt. B:",
+                    coordvec_label="Pt. B (Pivot):",
                     op_id_cursor_grab=(
                         "maplus.calcresultgrabplanebfromcursor"
                     ),

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -10565,10 +10565,7 @@ class QuickAlignPointsGUI(bpy.types.Panel):
                 modifier_header.label("Point Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = apt_src_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -10610,39 +10607,6 @@ class QuickAlignPointsGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
         if addon_data.quick_apt_show_src_geom:
             apt_grab_col.separator()
 
@@ -10703,10 +10667,7 @@ class QuickAlignPointsGUI(bpy.types.Panel):
             modifier_header.label("Point Modifiers:")
             apply_mods = modifier_header.row()
             apply_mods.alignment = 'RIGHT'
-            # apply_mods.operator(
-                # "maplus.applygeommodifiers",
-                # text="Apply ModifiersXXXXX"
-            # )
+
             item_mods_box = apt_dest_geom_editor.box()
             mods_row_1 = item_mods_box.row()
             mods_row_1.prop(
@@ -10747,8 +10708,6 @@ class QuickAlignPointsGUI(bpy.types.Panel):
                     "maplus.quickaptdestsendpointtocursor"
                 )
             )
-
-        ########################
 
         align_pts_gui.label("Operator settings:", icon="SCRIPTWIN")
         apt_mods = align_pts_gui.box()
@@ -10882,10 +10841,7 @@ class QuickAlignLinesGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = aln_src_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -10931,40 +10887,6 @@ class QuickAlignLinesGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=aln_src_geom_editor,
                     coordvec_label="End:",
@@ -10991,48 +10913,8 @@ class QuickAlignLinesGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
         if addon_data.quick_aln_show_src_geom:
             aln_grab_col.separator()
-
-        # apl_dest_geom = apl_grab_col.row()
-        # apl_grab_col.operator(
-                # "maplus.quickalignplanesgrabdest",
-                # icon='WORLD',
-                # text="Grab Destination"
-        # )
 
         aln_dest_geom_top = aln_grab_col.row(align=True)
         if not addon_data.quick_aln_show_dest_geom:
@@ -11096,10 +10978,7 @@ class QuickAlignLinesGUI(bpy.types.Panel):
             modifier_header.label("Line Modifiers:")
             apply_mods = modifier_header.row()
             apply_mods.alignment = 'RIGHT'
-            # apply_mods.operator(
-                # "maplus.applygeommodifiers",
-                # text="Apply ModifiersXXXXX"
-            # )
+
             item_mods_box = aln_dest_geom_editor.box()
             mods_row_1 = item_mods_box.row()
             mods_row_1.prop(
@@ -11145,40 +11024,6 @@ class QuickAlignLinesGUI(bpy.types.Panel):
                 )
             )
 
-            # component_changers_plna = plane_a_items.row()
-            # zero_components_plna = component_changers_plna.column(
-                # align=True
-            # )
-            # zero_components_plna.label("Set Zeroes:")
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointax",
-                # text="X00"
-            # )
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointay",
-                # text="0Y0"
-            # )
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointaz",
-                # text="00Z"
-            # )
-            # one_components_plna = component_changers_plna.column(
-                # align=True
-            # )
-            # one_components_plna.label("Set Ones:")
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointax",
-                # text="X11"
-            # )
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointay",
-                # text="1Y1"
-            # )
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointaz",
-                # text="11Z"
-            # )
-
             layout_coordvec(
                 parent_layout=aln_dest_geom_editor,
                 coordvec_label="End:",
@@ -11204,13 +11049,6 @@ class QuickAlignLinesGUI(bpy.types.Panel):
                     "Start"
                 )
             )
-
-        ###################################
-        ###################################
-
-
-        ###################################
-        ###################################
 
         aln_gui.label("Operator settings:", icon="SCRIPTWIN")
         aln_mods = aln_gui.box()
@@ -11348,40 +11186,6 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=apl_src_geom_editor,
                     coordvec_label="Pt. B (Pivot):",
@@ -11411,40 +11215,6 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
                         "C"
                     )
                 )
-
-                # component_changers_plnb = plane_b_items.row()
-                # zero_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # zero_components_plnb.label("Set Zeroes:")
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbx",
-                    # text="X00"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointby",
-                    # text="0Y0"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbz",
-                    # text="00Z"
-                # )
-                # one_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # one_components_plnb.label("Set Ones:")
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbx",
-                    # text="X11"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointby",
-                    # text="1Y1"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbz",
-                    # text="11Z"
-                # )
 
                 layout_coordvec(
                     parent_layout=apl_src_geom_editor,
@@ -11476,48 +11246,8 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
         if addon_data.quick_apl_show_src_geom:
             apl_grab_col.separator()
-
-        # apl_dest_geom = apl_grab_col.row()
-        # apl_grab_col.operator(
-                # "maplus.quickalignplanesgrabdest",
-                # icon='WORLD',
-                # text="Grab Destination"
-        # )
 
         apl_dest_geom_top = apl_grab_col.row(align=True)
         if not addon_data.quick_apl_show_dest_geom:
@@ -11596,40 +11326,6 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
                 )
             )
 
-            # component_changers_plna = plane_a_items.row()
-            # zero_components_plna = component_changers_plna.column(
-                # align=True
-            # )
-            # zero_components_plna.label("Set Zeroes:")
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointax",
-                # text="X00"
-            # )
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointay",
-                # text="0Y0"
-            # )
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointaz",
-                # text="00Z"
-            # )
-            # one_components_plna = component_changers_plna.column(
-                # align=True
-            # )
-            # one_components_plna.label("Set Ones:")
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointax",
-                # text="X11"
-            # )
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointay",
-                # text="1Y1"
-            # )
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointaz",
-                # text="11Z"
-            # )
-
             layout_coordvec(
                 parent_layout=apl_dest_geom_editor,
                 coordvec_label="Pt. B (Pivot):",
@@ -11660,40 +11356,6 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
                 )
             )
 
-            # component_changers_plnb = plane_b_items.row()
-            # zero_components_plnb = component_changers_plnb.column(
-                # align=True
-            # )
-            # zero_components_plnb.label("Set Zeroes:")
-            # zero_components_plnb.operator(
-                # "maplus.zerootherplanepointbx",
-                # text="X00"
-            # )
-            # zero_components_plnb.operator(
-                # "maplus.zerootherplanepointby",
-                # text="0Y0"
-            # )
-            # zero_components_plnb.operator(
-                # "maplus.zerootherplanepointbz",
-                # text="00Z"
-            # )
-            # one_components_plnb = component_changers_plnb.column(
-                # align=True
-            # )
-            # one_components_plnb.label("Set Ones:")
-            # one_components_plnb.operator(
-                # "maplus.oneotherplanepointbx",
-                # text="X11"
-            # )
-            # one_components_plnb.operator(
-                # "maplus.oneotherplanepointby",
-                # text="1Y1"
-            # )
-            # one_components_plnb.operator(
-                # "maplus.oneotherplanepointbz",
-                # text="11Z"
-            # )
-
             layout_coordvec(
                 parent_layout=apl_dest_geom_editor,
                 coordvec_label="Pt. C:",
@@ -11723,47 +11385,6 @@ class QuickAlignPlanesGUI(bpy.types.Panel):
                     "B"
                 )
             )
-
-            # component_changers_plnc = plane_c_items.row()
-            # zero_components_plnc = component_changers_plnc.column(
-                # align=True
-            # )
-            # zero_components_plnc.label("Set Zeroes:")
-            # zero_components_plnc.operator(
-                # "maplus.zerootherplanepointcx",
-                # text="X00"
-            # )
-            # zero_components_plnc.operator(
-                # "maplus.zerootherplanepointcy",
-                # text="0Y0"
-            # )
-            # zero_components_plnc.operator(
-                # "maplus.zerootherplanepointcz",
-                # text="00Z"
-            # )
-            # one_components_plnc = component_changers_plnc.column(
-                # align=True
-            # )
-            # one_components_plnc.label("Set Ones:")
-            # one_components_plnc.operator(
-                # "maplus.oneotherplanepointcx",
-                # text="X11"
-            # )
-            # one_components_plnc.operator(
-                # "maplus.oneotherplanepointcy",
-                # text="1Y1"
-            # )
-            # one_components_plnc.operator(
-                # "maplus.oneotherplanepointcz",
-                # text="11Z"
-            # )
-
-        ###################################
-        ###################################
-
-
-        ###################################
-        ###################################
 
         apl_gui.label("Operator settings:", icon="SCRIPTWIN")
         apl_mods = apl_gui.box()
@@ -11892,10 +11513,7 @@ class QuickAxisRotateGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = axr_src_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -11941,40 +11559,6 @@ class QuickAxisRotateGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=axr_src_geom_editor,
                     coordvec_label="End:",
@@ -12001,39 +11585,6 @@ class QuickAxisRotateGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
         if addon_data.quick_axr_show_src_geom:
             axr_grab_col.separator()
 
@@ -12159,10 +11710,7 @@ class QuickDirectionalSlideGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = ds_src_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -12208,40 +11756,6 @@ class QuickDirectionalSlideGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=ds_src_geom_editor,
                     coordvec_label="End:",
@@ -12268,39 +11782,6 @@ class QuickDirectionalSlideGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
         if addon_data.quick_ds_show_src_geom:
             ds_grab_col.separator()
 
@@ -12432,10 +11913,7 @@ class QuickSMEGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = sme_src_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -12481,40 +11959,6 @@ class QuickSMEGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=sme_src_geom_editor,
                     coordvec_label="End:",
@@ -12541,39 +11985,6 @@ class QuickSMEGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
         if addon_data.quick_sme_show_src_geom:
             sme_grab_col.separator()
 
@@ -12634,10 +12045,7 @@ class QuickSMEGUI(bpy.types.Panel):
             modifier_header.label("Line Modifiers:")
             apply_mods = modifier_header.row()
             apply_mods.alignment = 'RIGHT'
-            # apply_mods.operator(
-                # "maplus.applygeommodifiers",
-                # text="Apply ModifiersXXXXX"
-            # )
+
             item_mods_box = sme_dest_geom_editor.box()
             mods_row_1 = item_mods_box.row()
             mods_row_1.prop(
@@ -12682,40 +12090,6 @@ class QuickSMEGUI(bpy.types.Panel):
                     "End"
                 )
             )
-
-            # component_changers_plna = plane_a_items.row()
-            # zero_components_plna = component_changers_plna.column(
-                # align=True
-            # )
-            # zero_components_plna.label("Set Zeroes:")
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointax",
-                # text="X00"
-            # )
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointay",
-                # text="0Y0"
-            # )
-            # zero_components_plna.operator(
-                # "maplus.zerootherplanepointaz",
-                # text="00Z"
-            # )
-            # one_components_plna = component_changers_plna.column(
-                # align=True
-            # )
-            # one_components_plna.label("Set Ones:")
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointax",
-                # text="X11"
-            # )
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointay",
-                # text="1Y1"
-            # )
-            # one_components_plna.operator(
-                # "maplus.oneotherplanepointaz",
-                # text="11Z"
-            # )
 
             layout_coordvec(
                 parent_layout=sme_dest_geom_editor,
@@ -12891,10 +12265,7 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                 modifier_header.label("Point Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = slot1_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -12971,10 +12342,7 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
+
                 item_mods_box = slot1_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -13020,40 +12388,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=slot1_geom_editor,
                     coordvec_label="End:",
@@ -13080,39 +12414,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
             elif addon_data.internal_storage_slot_1.kind == 'PLANE':
                 plane_grab_all = slot1_geom_editor.row(align=True)
                 plane_grab_all.operator(
@@ -13167,40 +12468,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=slot1_geom_editor,
                     coordvec_label="Pt. B (Pivot):",
@@ -13231,40 +12498,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnb = plane_b_items.row()
-                # zero_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # zero_components_plnb.label("Set Zeroes:")
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbx",
-                    # text="X00"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointby",
-                    # text="0Y0"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbz",
-                    # text="00Z"
-                # )
-                # one_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # one_components_plnb.label("Set Ones:")
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbx",
-                    # text="X11"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointby",
-                    # text="1Y1"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=slot1_geom_editor,
                     coordvec_label="Pt. C:",
@@ -13294,40 +12527,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                         "B"
                     )
                 )
-
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
 
         if addon_data.quick_calc_show_slot1_geom:
                 calc_gui.separator()
@@ -13392,10 +12591,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                 modifier_header.label("Point Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
                 item_mods_box = slot2_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -13472,10 +12667,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
                 item_mods_box = slot2_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -13521,40 +12712,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=slot2_geom_editor,
                     coordvec_label="End:",
@@ -13581,39 +12738,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
             elif addon_data.internal_storage_slot_2.kind == 'PLANE':
                 plane_grab_all = slot2_geom_editor.row(align=True)
                 plane_grab_all.operator(
@@ -13668,40 +12792,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=slot2_geom_editor,
                     coordvec_label="Pt. B (Pivot):",
@@ -13731,40 +12821,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                         "C"
                     )
                 )
-
-                # component_changers_plnb = plane_b_items.row()
-                # zero_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # zero_components_plnb.label("Set Zeroes:")
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbx",
-                    # text="X00"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointby",
-                    # text="0Y0"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbz",
-                    # text="00Z"
-                # )
-                # one_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # one_components_plnb.label("Set Ones:")
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbx",
-                    # text="X11"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointby",
-                    # text="1Y1"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbz",
-                    # text="11Z"
-                # )
 
                 layout_coordvec(
                     parent_layout=slot2_geom_editor,
@@ -13796,39 +12852,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
         if addon_data.quick_calc_show_slot2_geom:
                 calc_gui.separator()
 
@@ -13909,10 +12932,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                 modifier_header.label("Point Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
                 item_mods_box = calcresult_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -13989,10 +13008,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                 modifier_header.label("Line Modifiers:")
                 apply_mods = modifier_header.row()
                 apply_mods.alignment = 'RIGHT'
-                # apply_mods.operator(
-                    # "maplus.applygeommodifiers",
-                    # text="Apply ModifiersXXXXX"
-                # )
                 item_mods_box = calcresult_geom_editor.box()
                 mods_row_1 = item_mods_box.row()
                 mods_row_1.prop(
@@ -14038,40 +13053,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=calcresult_geom_editor,
                     coordvec_label="End:",
@@ -14098,39 +13079,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
             elif addon_data.quick_calc_result_item.kind == 'PLANE':
                 plane_grab_all = calcresult_geom_editor.row(align=True)
                 plane_grab_all.operator(
@@ -14185,40 +13133,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=calcresult_geom_editor,
                     coordvec_label="Pt. B (Pivot):",
@@ -14249,40 +13163,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnb = plane_b_items.row()
-                # zero_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # zero_components_plnb.label("Set Zeroes:")
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbx",
-                    # text="X00"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointby",
-                    # text="0Y0"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbz",
-                    # text="00Z"
-                # )
-                # one_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # one_components_plnb.label("Set Ones:")
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbx",
-                    # text="X11"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointby",
-                    # text="1Y1"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=calcresult_geom_editor,
                     coordvec_label="Pt. C:",
@@ -14312,42 +13192,6 @@ class CalculateAndComposeGUI(bpy.types.Panel):
                         "B"
                     )
                 )
-
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
-        # if addon_data.quick_calc_show_calcresult_geom:
-                # calc_gui.separator()
 
         calc_gui.separator()
 

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -2268,7 +2268,7 @@ class GrabNormalBase(bpy.types.Operator):
 
             elif self.quick_op_target == "AXRSRC":
                 active_item = addon_data.quick_axis_rotate_src
-            
+
             elif self.quick_op_target == "SLOT1":
                 active_item = addon_data.internal_storage_slot_1
             elif self.quick_op_target == "SLOT2":
@@ -6275,7 +6275,7 @@ class ScaleMatchEdgeBase(bpy.types.Operator):
 
             # Get global coordinate data for each geometry item, with
             # applicable modifiers applied. Grab either (A) directly from
-            # the scene data (for quick ops), (B) from the MAPlus primitives 
+            # the scene data (for quick ops), (B) from the MAPlus primitives
             # CollectionProperty on the scene data (for advanced tools), or
             # (C) from the selected verts directly for numeric input mode
             if hasattr(self, "quick_op_target"):
@@ -6298,7 +6298,7 @@ class ScaleMatchEdgeBase(bpy.types.Operator):
                                 'Cannot grab coords: non-mesh or no active object.'
                             )
                             return {'CANCELLED'}
-                        
+
                         set_item_coords(
                             addon_data.quick_sme_numeric_src,
                             vert_attribs_to_set,
@@ -8370,7 +8370,7 @@ class CalcRotationalDiffBase(bpy.types.Operator):
             result = angle
         else:
             result = math.degrees(angle)
-        
+
         setattr(active_calculation, result_attrib, result)
         if addon_data.calc_result_to_clipboard:
             bpy.context.window_manager.clipboard = str(result)
@@ -9533,35 +9533,6 @@ class MAPlusGui(bpy.types.Panel):
                     )
                 )
 
-                # component_changers = pt_coord_items.row()
-                # zero_components = component_changers.column(align=True)
-                # zero_components.label("Set Zeroes:")
-                # zero_components.operator(
-                    # "maplus.zerootherpointx",
-                    # text="X00"
-                # )
-                # zero_components.operator(
-                    # "maplus.zerootherpointy",
-                    # text="0Y0"
-                # )
-                # zero_components.operator(
-                    # "maplus.zerootherpointz",
-                    # text="00Z"
-                # )
-                # one_components = component_changers.column(align=True)
-                # one_components.label("Set Ones:")
-                # one_components.operator(
-                    # "maplus.oneotherpointx",
-                    # text="X11"
-                # )
-                # one_components.operator(
-                    # "maplus.oneotherpointy",
-                    # text="1Y1"
-                # )
-                # one_components.operator(
-                    # "maplus.oneotherpointz",
-                    # text="11Z"
-                # )
                 item_info_col.separator()
                 item_info_col.operator(
                     "maplus.duplicateitembase",
@@ -9657,36 +9628,6 @@ class MAPlusGui(bpy.types.Panel):
                 )
                 item_info_col.separator()
 
-                # component_changers_start = ln_start_items.row()
-                # zero_components = component_changers_start.column(align=True)
-                # zero_components.label("Set Zeroes:")
-                # zero_components.operator(
-                    # "maplus.zerootherlinestartx",
-                    # text="X00"
-                # )
-                # zero_components.operator(
-                    # "maplus.zerootherlinestarty",
-                    # text="0Y0"
-                # )
-                # zero_components.operator(
-                    # "maplus.zerootherlinestartz",
-                    # text="00Z"
-                # )
-                # one_components = component_changers_start.column(align=True)
-                # one_components.label("Set Ones:")
-                # one_components.operator(
-                    # "maplus.oneotherlinestartx",
-                    # text="X11"
-                # )
-                # one_components.operator(
-                    # "maplus.oneotherlinestarty",
-                    # text="1Y1"
-                # )
-                # one_components.operator(
-                    # "maplus.oneotherlinestartz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=item_info_col,
                     coordvec_label="End:",
@@ -9713,35 +9654,6 @@ class MAPlusGui(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_end = ln_end_items.row()
-                # zero_components = component_changers_end.column(align=True)
-                # zero_components.label("Set Zeroes:")
-                # zero_components.operator(
-                    # "maplus.zerootherlineendx",
-                    # text="X00"
-                # )
-                # zero_components.operator(
-                    # "maplus.zerootherlineendy",
-                    # text="0Y0"
-                # )
-                # zero_components.operator(
-                    # "maplus.zerootherlineendz",
-                    # text="00Z"
-                # )
-                # one_components = component_changers_end.column(align=True)
-                # one_components.label("Set Ones:")
-                # one_components.operator(
-                    # "maplus.oneotherlineendx",
-                    # text="X11"
-                # )
-                # one_components.operator(
-                    # "maplus.oneotherlineendy",
-                    # text="1Y1"
-                # )
-                # one_components.operator(
-                    # "maplus.oneotherlineendz",
-                    # text="11Z"
-                # )
                 item_info_col.separator()
                 item_info_col.operator(
                     "maplus.duplicateitembase",
@@ -9806,40 +9718,6 @@ class MAPlusGui(bpy.types.Panel):
                 )
                 item_info_col.separator()
 
-                # component_changers_plna = plane_a_items.row()
-                # zero_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # zero_components_plna.label("Set Zeroes:")
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointax",
-                    # text="X00"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointay",
-                    # text="0Y0"
-                # )
-                # zero_components_plna.operator(
-                    # "maplus.zerootherplanepointaz",
-                    # text="00Z"
-                # )
-                # one_components_plna = component_changers_plna.column(
-                    # align=True
-                # )
-                # one_components_plna.label("Set Ones:")
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointax",
-                    # text="X11"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointay",
-                    # text="1Y1"
-                # )
-                # one_components_plna.operator(
-                    # "maplus.oneotherplanepointaz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=item_info_col,
                     coordvec_label="Pt. B:",
@@ -9871,40 +9749,6 @@ class MAPlusGui(bpy.types.Panel):
                 )
                 item_info_col.separator()
 
-                # component_changers_plnb = plane_b_items.row()
-                # zero_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # zero_components_plnb.label("Set Zeroes:")
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbx",
-                    # text="X00"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointby",
-                    # text="0Y0"
-                # )
-                # zero_components_plnb.operator(
-                    # "maplus.zerootherplanepointbz",
-                    # text="00Z"
-                # )
-                # one_components_plnb = component_changers_plnb.column(
-                    # align=True
-                # )
-                # one_components_plnb.label("Set Ones:")
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbx",
-                    # text="X11"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointby",
-                    # text="1Y1"
-                # )
-                # one_components_plnb.operator(
-                    # "maplus.oneotherplanepointbz",
-                    # text="11Z"
-                # )
-
                 layout_coordvec(
                     parent_layout=item_info_col,
                     coordvec_label="Pt. C:",
@@ -9935,39 +9779,6 @@ class MAPlusGui(bpy.types.Panel):
                     )
                 )
 
-                # component_changers_plnc = plane_c_items.row()
-                # zero_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # zero_components_plnc.label("Set Zeroes:")
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcx",
-                    # text="X00"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcy",
-                    # text="0Y0"
-                # )
-                # zero_components_plnc.operator(
-                    # "maplus.zerootherplanepointcz",
-                    # text="00Z"
-                # )
-                # one_components_plnc = component_changers_plnc.column(
-                    # align=True
-                # )
-                # one_components_plnc.label("Set Ones:")
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcx",
-                    # text="X11"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcy",
-                    # text="1Y1"
-                # )
-                # one_components_plnc.operator(
-                    # "maplus.oneotherplanepointcz",
-                    # text="11Z"
-                # )
                 item_info_col.separator()
                 item_info_col.operator(
                     "maplus.duplicateitembase",
@@ -11890,7 +11701,7 @@ class QuickSMEGUI(bpy.types.Panel):
                     icon='WORLD',
                     text="Grab All Global"
                 )
-                
+
                 special_grabs = sme_src_geom_editor.row(align=True)
                 special_grabs.operator(
                     "maplus.quicksmegrabnormalsrc",

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -577,7 +577,9 @@ class MAPlusData(bpy.types.PropertyGroup):
     # Calculation global settings
     calc_result_to_clipboard = bpy.props.BoolProperty(
         description=(
-            "Copy numeric calculations to clipboard"
+            "Copy  calculation results (new reference locations or"
+            " numeric calculations) to the addon clipboard or the"
+            " system clipboard, respectively."
         ),
         default=True
     )
@@ -13817,8 +13819,8 @@ class CalculateAndComposeGUI(bpy.types.Panel):
             preserve_button_roundedge = result_geom_top.row()
             preserve_button_roundedge.operator(
                 "maplus.graballcalcresult",
-                icon='WORLD',
-                text="Grab Calc. Result"
+                icon='SOLO_ON',
+                text="S. Grab Result"
             )
 
         else:

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -4109,6 +4109,17 @@ class GrabLineCalcResultLoc(GrabFromGeometryBase):
     quick_op_target = "CALCRESULT"
 
 
+class GrabNormal(GrabNormalBase):
+    bl_idname = "maplus.grabnormal"
+    bl_label = "Grab Normal Coords from Selected Face"
+    bl_description = (
+        "Grabs normal coordinates from selected face in edit mode"
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+    vert_attribs_to_set = ('line_start', 'line_end')
+    multiply_by_world_matrix = True
+
+
 class Slot1GrabNormal(GrabNormalBase):
     bl_idname = "maplus.slot1grabnormal"
     bl_label = "Grab Normal Coords from Selected Face"
@@ -9558,11 +9569,18 @@ class MAPlusGui(bpy.types.Panel):
                 item_info_col.separator()
                 special_grabs = item_info_col.row(align=True)
                 special_grabs.operator(
+                    "maplus.grabnormal",
+                    icon='LAMP_HEMI',
+                    text="Grab Normal"
+                )
+                item_info_col.separator()
+                special_grabs_extra = item_info_col.row(align=True)
+                special_grabs_extra.operator(
                     "maplus.copyfromadvtoolsactive",
                     icon='COPYDOWN',
                     text="Copy (To Clipboard)"
                 )
-                special_grabs.operator(
+                special_grabs_extra.operator(
                     "maplus.pasteintoadvtoolsactive",
                     icon='PASTEDOWN',
                     text="Paste (From Clipboard)"

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -6239,10 +6239,10 @@ class ScaleMatchEdgeBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
-        if not bpy.context.active_object:
+        if not (bpy.context.active_object and bpy.context.active_object.select):
             self.report(
                 {'ERROR'},
-                'Cannot complete: no active object.'
+                'Cannot complete: need at least one active (and selected) object.'
             )
             return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
@@ -6620,10 +6620,10 @@ class AlignPointsBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
-        if not bpy.context.active_object:
+        if not (bpy.context.active_object and bpy.context.active_object.select):
             self.report(
                 {'ERROR'},
-                'Cannot complete: no active object.'
+                'Cannot complete: need at least one active (and selected) object.'
             )
             return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
@@ -6896,10 +6896,10 @@ class DirectionalSlideBase(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
-        if not bpy.context.active_object:
+        if not (bpy.context.active_object and bpy.context.active_object.select):
             self.report(
                 {'ERROR'},
-                'Cannot complete: no active object.'
+                'Cannot complete: need at least one active (and selected) object.'
             )
             return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
@@ -7178,10 +7178,10 @@ class AxisRotateBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
-        if not bpy.context.active_object:
+        if not (bpy.context.active_object and bpy.context.active_object.select):
             self.report(
                 {'ERROR'},
-                'Cannot complete: no active object.'
+                'Cannot complete: need at least one active (and selected) object.'
             )
             return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
@@ -7481,10 +7481,10 @@ class AlignLinesBase(bpy.types.Operator):
     target = None
 
     def execute(self, context):
-        if not bpy.context.active_object:
+        if not (bpy.context.active_object and bpy.context.active_object.select):
             self.report(
                 {'ERROR'},
-                'Cannot complete: no active object.'
+                'Cannot complete: need at least one active (and selected) object.'
             )
             return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data
@@ -7802,10 +7802,10 @@ class AlignPlanesBase(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
-        if not bpy.context.active_object:
+        if not (bpy.context.active_object and bpy.context.active_object.select):
             self.report(
                 {'ERROR'},
-                'Cannot complete: no active object.'
+                'Cannot complete: need at least one active (and selected) object.'
             )
             return {'CANCELLED'}
         addon_data = bpy.context.scene.maplus_data

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -12799,8 +12799,8 @@ class CalculateAndComposeGUI(bpy.types.Panel):
             preserve_button_roundedge = slot1_geom_top.row()
             preserve_button_roundedge.operator(
                 "maplus.graballslot1",
-                icon='WORLD',
-                text="Grab Slot 1"
+                icon='SOLO_ON',
+                text="S. Grab Slot 1"
             )
 
         else:
@@ -13300,8 +13300,8 @@ class CalculateAndComposeGUI(bpy.types.Panel):
             preserve_button_roundedge = slot2_geom_top.row()
             preserve_button_roundedge.operator(
                 "maplus.graballslot2",
-                icon='WORLD',
-                text="Grab Slot 2"
+                icon='SOLO_ON',
+                text="S. Grab Slot 2"
             )
 
         else:

--- a/mesh_mesh_align_plus.py
+++ b/mesh_mesh_align_plus.py
@@ -1333,6 +1333,24 @@ class CopyToOtherBase(bpy.types.Operator):
         return {'FINISHED'}
 
 
+class PasteIntoAdvToolsActive(CopyToOtherBase):
+    bl_idname = "maplus.pasteintoadvtoolsactive"
+    bl_label = "Paste into this item"
+    bl_description = "Pastes from the internal clipboard into this item"
+    bl_options = {'REGISTER', 'UNDO'}
+    # A tuple of strings indicating the source and destination
+    source_dest_pair = ('INTERNALCLIPBOARD', 'ADVTOOLSACTIVE')
+
+
+class CopyFromAdvToolsActive(CopyToOtherBase):
+    bl_idname = "maplus.copyfromadvtoolsactive"
+    bl_label = "Copy from this item"
+    bl_description = "Copies this item into the internal clipboard"
+    bl_options = {'REGISTER', 'UNDO'}
+    # A tuple of strings indicating the source and destination
+    source_dest_pair = ('ADVTOOLSACTIVE', 'INTERNALCLIPBOARD')
+
+
 class PasteIntoSlot1(CopyToOtherBase):
     bl_idname = "maplus.pasteintoslot1"
     bl_label = "Paste into this item"
@@ -9426,6 +9444,18 @@ class MAPlusGui(bpy.types.Panel):
                     text="Grab All Global"
                 )
                 item_info_col.separator()
+                special_grabs = item_info_col.row(align=True)
+                special_grabs.operator(
+                    "maplus.copyfromadvtoolsactive",
+                    icon='COPYDOWN',
+                    text="Copy (To Clipboard)"
+                )
+                special_grabs.operator(
+                    "maplus.pasteintoadvtoolsactive",
+                    icon='PASTEDOWN',
+                    text="Paste (From Clipboard)"
+                )
+                item_info_col.separator()
 
                 layout_coordvec(
                     parent_layout=item_info_col,
@@ -9524,6 +9554,18 @@ class MAPlusGui(bpy.types.Panel):
                     "maplus.graballvertslineglobal",
                     icon='WORLD',
                     text="Grab All Global"
+                )
+                item_info_col.separator()
+                special_grabs = item_info_col.row(align=True)
+                special_grabs.operator(
+                    "maplus.copyfromadvtoolsactive",
+                    icon='COPYDOWN',
+                    text="Copy (To Clipboard)"
+                )
+                special_grabs.operator(
+                    "maplus.pasteintoadvtoolsactive",
+                    icon='PASTEDOWN',
+                    text="Paste (From Clipboard)"
                 )
                 item_info_col.separator()
 
@@ -9657,6 +9699,18 @@ class MAPlusGui(bpy.types.Panel):
                     "maplus.graballvertsplaneglobal",
                     icon='WORLD',
                     text="Grab All Global"
+                )
+                item_info_col.separator()
+                special_grabs = item_info_col.row(align=True)
+                special_grabs.operator(
+                    "maplus.copyfromadvtoolsactive",
+                    icon='COPYDOWN',
+                    text="Copy (To Clipboard)"
+                )
+                special_grabs.operator(
+                    "maplus.pasteintoadvtoolsactive",
+                    icon='PASTEDOWN',
+                    text="Paste (From Clipboard)"
                 )
                 item_info_col.separator()
 


### PR DESCRIPTION
**when the autodetection boxes are activated it is quite confusing to be reading a lot of errors that the console throws, more annoying is when you are developing something inside the src of the blender, and you do not know if this is because you did something wrong or is something else completely foreign to your development**

I suggest that you leave them off and that the user activates them when needed, it is very annoying when one has to be reading the console continuously, having to filter this lack of care that your add-on has.
I realized until I started to deactivate boxes of the few add-ons I've installed
![blender_2019-01-07_12-26-08](https://user-images.githubusercontent.com/24207840/50788269-8353d780-127e-11e9-8df1-0c05b824fa8f.png)


`Traceback (most recent call last):
  File "C:\Users\User\AppData\Roaming\Blender Foundation\Blender\2.79\scripts\addons\mesh_align_to_gpencil_view.py", line 163, in poll
    return check_if_any_gp_exists(context)
  File "C:\Users\User\AppData\Roaming\Blender Foundation\Blender\2.79\scripts\addons\mesh_align_to_gpencil_view.py", line 423, in check_if_any_gp_exists
    if(check_if_object_gp_exists(context)):
  File "C:\Users\User\AppData\Roaming\Blender Foundation\Blender\2.79\scripts\addons\mesh_align_to_gpencil_view.py", line 432, in check_if_object_gp_exists
    objectGP = bpy.context.active_object.grease_pencil
AttributeError: 'NoneType' object has no attribute 'grease_pencil'

location: <unknown location>:-1`

![2019-01-07_12-57-25](https://user-images.githubusercontent.com/24207840/50787993-b8135f00-127d-11e9-8bde-9939651f4b38.png)
